### PR TITLE
Raw pointer impl

### DIFF
--- a/TestDeepPtr.cpp
+++ b/TestDeepPtr.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Pointer constructor","[deep_ptr.constructors]")
   GIVEN("A pointer-constructed deep_ptr")
   {
     int derived_type_value = 7;
-    deep_ptr<BaseType> dptr = make_deep_ptr<DerivedType>(derived_type_value);
+    deep_ptr<BaseType> dptr = make_deep_ptr<BaseType, DerivedType>(derived_type_value);
 
     THEN("get returns a non-null pointer")
     {
@@ -112,7 +112,7 @@ TEST_CASE("Pointer constructor","[deep_ptr.constructors]")
   GIVEN("A pointer-constructed const deep_ptr")
   {
     int derived_type_value = 7;
-    const deep_ptr<BaseType> cdptr = make_deep_ptr<DerivedType>(derived_type_value);
+    const deep_ptr<BaseType> cdptr = make_deep_ptr<BaseType, DerivedType>(derived_type_value);
 
     THEN("get returns a non-null pointer")
     {
@@ -141,7 +141,7 @@ TEST_CASE("deep_ptr destructor","[deep_ptr.destructor]")
     {
       // begin and end scope to force destruction
       {
-        deep_ptr<BaseType> tmp = make_deep_ptr<DerivedType>();
+        deep_ptr<BaseType> tmp = make_deep_ptr<BaseType, DerivedType>();
         REQUIRE(DerivedType::object_count == 1);
       }
       REQUIRE(DerivedType::object_count == 0);
@@ -177,7 +177,7 @@ TEST_CASE("deep_ptr copy constructor","[deep_ptr.constructors]")
     REQUIRE(DerivedType::object_count == 0);
 
     int derived_type_value = 7;
-    deep_ptr<BaseType> original_dptr = make_deep_ptr<DerivedType>(derived_type_value);
+    deep_ptr<BaseType> original_dptr = make_deep_ptr<BaseType, DerivedType>(derived_type_value);
     deep_ptr<BaseType> dptr(original_dptr);
 
     THEN("get returns a distinct non-null pointer")
@@ -215,25 +215,6 @@ TEST_CASE("deep_ptr copy constructor","[deep_ptr.constructors]")
   }
 }
 
-TEST_CASE("derived deep_ptr copy constructor", "[deep_ptr.constructors]")
-{
-  GIVEN("A deep_ptr to a BaseType copy-constructed from a deep_ptr to a derived type")
-  {
-    int derived_type_value = 7;
-    CHECK(DerivedType::object_count == 0);
-
-    deep_ptr<DerivedType> derived = make_deep_ptr<DerivedType>(derived_type_value);
-    CHECK(DerivedType::object_count == 1);
-
-    deep_ptr<BaseType> base(derived);
-
-    THEN("object count is 2")
-    {
-      REQUIRE(DerivedType::object_count == 2);
-    }
-  }
-}
-
 TEST_CASE("deep_ptr move constructor","[deep_ptr.constructors]")
 {
   GIVEN("A deep_ptr move-constructed from a default-constructed deep_ptr")
@@ -259,7 +240,7 @@ TEST_CASE("deep_ptr move constructor","[deep_ptr.constructors]")
   GIVEN("A deep_ptr move-constructed from a default-constructed deep_ptr")
   {
     int derived_type_value = 7;
-    deep_ptr<BaseType> original_dptr = make_deep_ptr<DerivedType>(derived_type_value);
+    deep_ptr<BaseType> original_dptr = make_deep_ptr<BaseType, DerivedType>(derived_type_value);
     auto original_pointer = original_dptr.get();
     CHECK(DerivedType::object_count == 1);
 
@@ -316,7 +297,7 @@ TEST_CASE("deep_ptr assignment","[deep_ptr.assignment]")
   {
     int v1 = 7;
 
-    deep_ptr<BaseType> dptr1 = make_deep_ptr<DerivedType>(v1);
+    deep_ptr<BaseType> dptr1 = make_deep_ptr<BaseType, DerivedType>(v1);
     const deep_ptr<BaseType> dptr2;
     const auto p = dptr2.get();
 
@@ -342,7 +323,7 @@ TEST_CASE("deep_ptr assignment","[deep_ptr.assignment]")
     int v1 = 7;
 
     deep_ptr<BaseType> dptr1;
-    const deep_ptr<BaseType> dptr2 = make_deep_ptr<DerivedType>(v1);
+    const deep_ptr<BaseType> dptr2 = make_deep_ptr<BaseType, DerivedType>(v1);
     const auto p = dptr2.get();
 
     REQUIRE(DerivedType::object_count == 1);
@@ -378,8 +359,8 @@ TEST_CASE("deep_ptr assignment","[deep_ptr.assignment]")
     int v1 = 7;
     int v2 = 87;
 
-    deep_ptr<BaseType> dptr1 = make_deep_ptr<DerivedType>(v1);
-    const deep_ptr<BaseType> dptr2 = make_deep_ptr<DerivedType>(v2);
+    deep_ptr<BaseType> dptr1 = make_deep_ptr<BaseType, DerivedType>(v1);
+    const deep_ptr<BaseType> dptr2 = make_deep_ptr<BaseType, DerivedType>(v2);
     const auto p = dptr2.get();
 
     REQUIRE(DerivedType::object_count == 2);
@@ -413,7 +394,7 @@ TEST_CASE("deep_ptr assignment","[deep_ptr.assignment]")
   {
     int v1 = 7;
 
-    deep_ptr<BaseType> dptr1 = make_deep_ptr<DerivedType>(v1);
+    deep_ptr<BaseType> dptr1 = make_deep_ptr<BaseType, DerivedType>(v1);
     const auto p = dptr1.get();
 
     REQUIRE(DerivedType::object_count == 1);
@@ -458,7 +439,7 @@ TEST_CASE("deep_ptr move-assignment","[deep_ptr.assignment]")
   {
     int v1 = 7;
 
-    deep_ptr<BaseType> dptr1 = make_deep_ptr<DerivedType>(v1);
+    deep_ptr<BaseType> dptr1 = make_deep_ptr<BaseType, DerivedType>(v1);
     deep_ptr<BaseType> dptr2;
     const auto p = dptr2.get();
 
@@ -484,7 +465,7 @@ TEST_CASE("deep_ptr move-assignment","[deep_ptr.assignment]")
     int v1 = 7;
 
     deep_ptr<BaseType> dptr1;
-    deep_ptr<BaseType> dptr2 = make_deep_ptr<DerivedType>(v1);
+    deep_ptr<BaseType> dptr2 = make_deep_ptr<BaseType, DerivedType>(v1);
     const auto p = dptr2.get();
 
     REQUIRE(DerivedType::object_count == 1);
@@ -509,8 +490,8 @@ TEST_CASE("deep_ptr move-assignment","[deep_ptr.assignment]")
     int v1 = 7;
     int v2 = 87;
 
-    deep_ptr<BaseType> dptr1 = make_deep_ptr<DerivedType>(v1);
-    deep_ptr<BaseType> dptr2 = make_deep_ptr<DerivedType>(v2);
+    deep_ptr<BaseType> dptr1 = make_deep_ptr<BaseType, DerivedType>(v1);
+    deep_ptr<BaseType> dptr2 = make_deep_ptr<BaseType, DerivedType>(v2);
     const auto p = dptr2.get();
 
     REQUIRE(DerivedType::object_count == 2);
@@ -534,7 +515,7 @@ TEST_CASE("deep_ptr move-assignment","[deep_ptr.assignment]")
   {
     int v1 = 7;
 
-    deep_ptr<BaseType> dptr1 = make_deep_ptr<DerivedType>(v1);
+    deep_ptr<BaseType> dptr1 = make_deep_ptr<BaseType, DerivedType>(v1);
     const auto p = dptr1.get();
 
     REQUIRE(DerivedType::object_count == 1);
@@ -550,21 +531,7 @@ TEST_CASE("deep_ptr move-assignment","[deep_ptr.assignment]")
   }
 }
 
-TEST_CASE("cast from a raw pointer", "[deep_ptr.deep_ptr_cast]")
-{
-  GIVEN("A unique_ptr to a derived object")
-  {
-    int derived_type_value = 7;
-    auto ptr = std::make_unique<DerivedType>(derived_type_value);
-
-    THEN("A deep_ptr to a copy_constructed DerivedType can be constructed using deep_ptr_cast")
-    {
-      auto dptr = deep_ptr_cast<DerivedType>(ptr.release());
-      REQUIRE(dptr->value() == derived_type_value);
-    }
-  }
-}
-
+/* Gustafsson's dilemma is fixed as the problematic code no longer compiles
 struct BaseA { int a_ = 0; virtual ~BaseA() = default; };
 struct BaseB { int b_ = 42; virtual ~BaseB() = default; };
 struct IntermediateBaseA : BaseA { int ia_ = 3; };
@@ -576,7 +543,7 @@ TEST_CASE("Gustafsson's dilemma: multiple (virtual) base classes", "[deep_ptr.co
   GIVEN("A value-constructed multiply-derived-class deep_ptr")
   {
     int derived_type_value = 7;
-    auto dptr = make_deep_ptr<MultiplyDerived>(derived_type_value);
+    auto dptr = make_deep_ptr<MultiplyDerived, MultiplyDerived>(derived_type_value);
 
     THEN("When copied to a deep_ptr to an intermediate base type, data is accessible as expected")
     {
@@ -593,3 +560,4 @@ TEST_CASE("Gustafsson's dilemma: multiple (virtual) base classes", "[deep_ptr.co
     }
   }
 }
+*/

--- a/deep_ptr.h
+++ b/deep_ptr.h
@@ -1,117 +1,88 @@
 #include <type_traits>
 #include <cassert>
 
-template <typename T> class deep_ptr;
-template <typename T, typename ...Ts> deep_ptr<T> make_deep_ptr(Ts&& ...ts);
-template <typename T, typename U> deep_ptr<T> deep_ptr_cast(U* u);
-
+template <typename T>
 struct deleter {
-  virtual void do_delete(const void *ptr) const = 0;
-  virtual std::unique_ptr<deleter> clone_self() const = 0;
+  virtual ~deleter() = default;
+  virtual void do_delete(const T *ptr) const = 0;
+  virtual std::unique_ptr<deleter<T>> clone_self() const = 0;
 };
 
-template <typename U> struct default_deleter : deleter {
-  void do_delete(const void *ptr) const override {
+template <typename T, typename U> struct default_deleter : deleter<T> {
+  void do_delete(const T *ptr) const override {
     delete static_cast<const U *>(ptr);
   }
-  std::unique_ptr<deleter> clone_self() const override {
-    return std::make_unique<default_deleter<U>>(*this);
+  std::unique_ptr<deleter<T>> clone_self() const override {
+    return std::make_unique<default_deleter<T,U>>(*this);
   }
 };
 
+template <typename T>
 struct cloner {
-  virtual void clone(const void *ptr, void** output) const = 0;
-  virtual std::unique_ptr<cloner> clone_self() const = 0;
+  virtual ~cloner() = default;
+  virtual T* clone(const T *ptr) const = 0;
+  virtual std::unique_ptr<cloner<T>> clone_self() const = 0;
 };
 
-template <typename U> struct default_cloner : cloner {
-  void clone(const void *ptr, void** output) const override {
-    *output = new U(*static_cast<const U *>(ptr));
+template <typename T, typename U> struct default_cloner : cloner<T> {
+  T* clone(const T *ptr) const override {
+    return new U(*static_cast<const U*>(ptr));
   }
-  std::unique_ptr<cloner> clone_self() const override {
-    return std::make_unique<default_cloner<U>>(*this);
+  std::unique_ptr<cloner<T>> clone_self() const override {
+    return std::make_unique<default_cloner<T,U>>(*this);
   }
 };
 
 template <typename T> class deep_ptr {
 
-  template <typename U> friend class deep_ptr;
-
-  // make_deep_ptr friendship is more permissive than we would ideally like but
-  // we cannot restrict make_deep_ptr by partial specialization.
-  //
-  // C++ Standard(§14.5.4/8): Friend declarations shall not declare partial
-  // specializations.
-  //
-  template <typename T_, typename... Ts>
-  friend deep_ptr<T_> make_deep_ptr(Ts &&... ts);
-
-  template <typename T_, typename U>
-  friend deep_ptr<T_> deep_ptr_cast(U* u);
-
   T* ptr_ = nullptr;
-  std::unique_ptr<deleter> deleter_;
-  std::unique_ptr<cloner> cloner_;
+  std::unique_ptr<deleter<T>> deleter_;
+  std::unique_ptr<cloner<T>> cloner_;
 
-  template <typename U,
-            typename V = std::enable_if_t<std::is_same<T, U>::value ||
-                                          std::is_base_of<T, U>::value>>
-  void do_copy_construct(const deep_ptr<U> &u) {
-    if (!u.ptr_) {
+  void do_copy_construct(const deep_ptr &p) {
+    if (!p.ptr_) {
       ptr_ = nullptr;
       return;  
     }
 
-    deleter_ = u.deleter_->clone_self();
-    cloner_ = u.cloner_->clone_self();
+    deleter_ = p.deleter_->clone_self();
+    cloner_ = p.cloner_->clone_self();
     
-    assert(u.cloner_);
-    u.cloner_->clone(u.ptr_, &ptr_);
+    assert(p.cloner_);
+    ptr_ = p.cloner_->clone(p.ptr_);
   }
 
-  template <typename U,
-            typename V = std::enable_if_t<std::is_same<T, U>::value ||
-                                          std::is_base_of<T, U>::value>>
-  deep_ptr &do_assign(const deep_ptr<U> &u) {
-    // protect against self-assignment
-    //if (static_cast<const T*>(&u.ptr_) == static_cast<const T*>(ptr_)) {
-    //  return *this;
-    //}
-
-    do_copy_construct(u);
-    
-    return *this;
-  }
-
-  template <typename U,
-            typename V = std::enable_if_t<std::is_same<T, U>::value ||
-                                          std::is_base_of<T, U>::value>>
-  void do_move_construct(deep_ptr<U> &&u) {
-    deleter_ = std::move(u.deleter_);
-    cloner_ = std::move(u.cloner_);
-    ptr_ = u.ptr_;
-    u.ptr_ = nullptr;
-  }
-
-  template <typename U,
-            typename V = std::enable_if_t<std::is_same<T, U>::value ||
-                                          std::is_base_of<T, U>::value>>
-  deep_ptr &do_move_assign(deep_ptr<U> &&u) {
-    do_move_construct(std::move(u));
-    return *this;
-  }
-
-  template <typename U,
-            typename V = std::enable_if_t<std::is_same<T, U>::value ||
-                                          std::is_base_of<T, U>::value>>
-  deep_ptr(U *u) {
-    if (!u) {
-      return;
+  deep_ptr &do_assign(const deep_ptr &p) {
+    if (&p == this) {
+      return *this;
     }
 
-    deleter_ = std::make_unique<default_deleter<U>>();
-    cloner_ = std::make_unique<default_cloner<U>>();
-    ptr_ = u;
+    if (ptr_) {
+      assert(deleter_);
+      deleter_->do_delete(ptr_);
+    }
+
+    do_copy_construct(p);
+    
+    return *this;
+  }
+
+  void do_move_construct(deep_ptr &&p) {
+    if (ptr_) {
+      assert(deleter_);
+      deleter_->do_delete(ptr_);
+    }
+    
+    deleter_ = std::move(p.deleter_);
+    cloner_ = std::move(p.cloner_);
+    ptr_ = p.ptr_;
+
+    p.ptr_ = nullptr;
+  }
+
+  deep_ptr &do_move_assign(deep_ptr &&u) {
+    do_move_construct(std::move(u));
+    return *this;
   }
 
 public:
@@ -129,31 +100,31 @@ public:
 
   deep_ptr(std::nullptr_t) : deep_ptr() {}
 
+  template <typename U,
+            typename V = std::enable_if_t<std::is_same<T, U>::value ||
+                                          std::is_base_of<T, U>::value>>
+  explicit deep_ptr(U *u) {
+    if (!u) {
+      return;
+    }
+
+    deleter_ = std::make_unique<default_deleter<T, U>>();
+    cloner_ = std::make_unique<default_cloner<T, U>>();
+    ptr_ = u;
+  }
   //
   // Copy-constructors
   //
 
   deep_ptr(const deep_ptr &p) { do_copy_construct(p); }
 
-  template <typename U,
-            typename V = std::enable_if_t<!std::is_same<T, U>::value &&
-                                          std::is_base_of<T, U>::value>>
-  deep_ptr(const deep_ptr<U> &u) {
-    do_copy_construct(u);
-  }
 
   //
   // Move-constructors
   //
 
   deep_ptr(deep_ptr &&p) { do_move_construct(std::move(p)); }
-
-  template <typename U,
-            typename V = std::enable_if_t<!std::is_same<T, U>::value &&
-                                          std::is_base_of<T, U>::value>>
-  deep_ptr(deep_ptr<U> &&u) {
-    do_move_construct(std::move(u));
-  }
+  
 
   //
   // Assignment
@@ -161,12 +132,6 @@ public:
 
   deep_ptr &operator=(const deep_ptr &p) { return do_assign(p); }
 
-  template <typename U,
-            typename V = std::enable_if_t<!std::is_same<T, U>::value &&
-                                          std::is_base_of<T, U>::value>>
-  deep_ptr &operator=(const deep_ptr<U> &u) {
-    return do_assign(u);
-  }
 
   //
   // Move-assignment
@@ -174,12 +139,6 @@ public:
 
   deep_ptr &operator=(deep_ptr &&p) { return do_move_assign(std::move(p)); }
 
-  template <typename U,
-            typename V = std::enable_if_t<!std::is_same<T, U>::value &&
-                                          std::is_base_of<T, U>::value>>
-  deep_ptr &operator=(deep_ptr<U> &&u) {
-    return do_move_assign(std::move(u));
-  }
 
   //
   // Accessors
@@ -214,15 +173,9 @@ public:
   }
 };
 
-template <typename T, typename ...Ts>
+template <typename T, typename U, typename ...Ts>
 deep_ptr<T> make_deep_ptr(Ts&& ...ts)
 {
-  return deep_ptr<T>(new T(std::forward<Ts>(ts)...));
-}
-
-template <typename T, typename U>
-deep_ptr<T> deep_ptr_cast(U* u)
-{
-  return deep_ptr<T>(u);
+  return deep_ptr<T>(new U(std::forward<Ts>(ts)...));
 }
 


### PR DESCRIPTION
A new simpler design solves 'Gustafsson's dilemma' by preventing construction and assignment of base type deep_ptrs from derived_type deep_ptrs.

The buffer has been removed and replaced with a raw pointer. The deleted and cloner are now potentially customizeable.